### PR TITLE
feat: Pricing (Fiyat Kartları) bölümü eklendi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # 📘 CHANGELOG
+
+## [0.2.0] - 2025-11-06
+### Added
+- Pricing (Fiyat Kartları) bölümü eklendi.
+- “Popüler” rozetli plan, erişilebilirlik (aria, focus-visible) ve responsive grid yapıldı.
+
 ## [0.1.0] - 2025-11-06
 ### Added
 - Features Section eklendi.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,6 @@
 import Features from "./sections/Features/Features";
 import Hero from "./sections/Hero/Hero";
+import Pricing from "./sections/Pricing/Pricing";
 
 
 function App() {
@@ -7,6 +8,7 @@ function App() {
     <>
     <Hero/>
     <Features/>
+    <Pricing/>
     </>
   );
 }

--- a/src/sections/Pricing/Pricing.jsx
+++ b/src/sections/Pricing/Pricing.jsx
@@ -1,0 +1,76 @@
+import styles from './Pricing.module.scss';
+import Button from '../../components/Button/Button';
+
+const plans = [
+  {
+    name: 'Starter',
+    price: '₺0',
+    period: '/ay',
+    features: ['1 proje', 'Temel bileşenler', 'Topluluk desteği'],
+    cta: 'Başla',
+    popular: false,
+  },
+  {
+    name: 'Pro',
+    price: '₺129',
+    period: '/ay',
+    features: ['Sınırsız proje', 'Tüm bileşenler', 'Öncelikli destek'],
+    cta: 'Satın Al',
+    popular: true, // “popüler” rozet
+  },
+  {
+    name: 'Team',
+    price: '₺249',
+    period: '/ay',
+    features: ['Takım çalışma alanı', 'Tema desteği', 'E-posta desteği'],
+    cta: 'Satın Al',
+    popular: false,
+  },
+];
+
+export default function Pricing() {
+  return (
+    <section className={styles.pricing} aria-labelledby="pricing-title">
+      <div className={styles.container}>
+        <h2 id="pricing-title" className={styles.title}>Fiyat Kartları</h2>
+        <p className={styles.subtitle}>
+          İhtiyacına uygun planı seç. Kartlar klavye ile gezinmeye ve ekranda okunabilirliğe uygundur.
+        </p>
+
+        <div className={styles.grid} role="list">
+          {plans.map((p) => (
+            <article
+              key={p.name}
+              className={`${styles.card} ${p.popular ? styles.popular : ''}`}
+              role="listitem"
+              aria-label={`${p.name} planı`}
+              tabIndex={0} // klavye erişimi
+            >
+              {p.popular && <span className={styles.badge} aria-label="Popüler plan">Popüler</span>}
+
+              <header className={styles.header}>
+                <h3 className={styles.planName}>{p.name}</h3>
+                <div className={styles.price} aria-label={`Fiyat ${p.price} ${p.period}`}>
+                  <span className={styles.amount}>{p.price}</span>
+                  <span className={styles.period}>{p.period}</span>
+                </div>
+              </header>
+
+              <ul className={styles.features} aria-label="Özellik listesi">
+                {p.features.map((f) => (
+                  <li key={f} className={styles.featureItem}>
+                    <span aria-hidden="true">✓</span> {f}
+                  </li>
+                ))}
+              </ul>
+
+              <div className={styles.actions}>
+                <Button label={p.cta} variant={p.popular ? 'primary' : 'secondary'} />
+              </div>
+            </article>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/sections/Pricing/Pricing.module.scss
+++ b/src/sections/Pricing/Pricing.module.scss
@@ -1,0 +1,85 @@
+@import '../../styles/variables';
+@import '../../styles/mixins';
+
+.pricing {
+  padding: 5rem 0;
+  background: var(--bg-color);
+  color: var(--text-color);
+}
+
+.container { @include container; text-align: center; }
+
+.title {
+  font-size: clamp(1.6rem, 1.2rem + 1.2vw, 2.2rem);
+  font-weight: 800;
+  letter-spacing: -.02em;
+  margin-bottom: .75rem;
+}
+
+.subtitle {
+  opacity: .9;
+  max-width: 720px;
+  margin: 0 auto 2.25rem auto;
+  font-size: 1.05rem;
+}
+
+.grid {
+  display: grid;
+  gap: 1.25rem;
+  align-items: stretch;
+
+  /* mobile-first */
+  grid-template-columns: 1fr;
+
+  @media (min-width: 641px) and (max-width: 1024px) { grid-template-columns: repeat(2, 1fr); }
+  @media (min-width: 1025px) { grid-template-columns: repeat(3, 1fr); }
+}
+
+.card {
+  position: relative;
+  background: var(--card-bg);
+  color: var(--text-color);
+  border-radius: var(--border-radius);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  padding: 1.25rem 1.25rem 1.5rem;
+  outline: none;
+  transition: transform .2s ease, box-shadow .2s ease, background .2s ease;
+
+  &:hover, &:focus-visible {
+    background: var(--card-bg-hover);
+    transform: translateY(-4px);
+    box-shadow: 0 10px 24px rgba(0,0,0,.12);
+  }
+}
+
+.badge {
+  position: absolute;
+  top: .75rem;
+  right: .75rem;
+  background: var(--primary-color);
+  color: #fff;
+  font-size: .75rem;
+  padding: .25rem .5rem;
+  border-radius: 999px;
+}
+
+.popular {
+  border: 2px solid var(--primary-color);
+}
+
+.header { margin-bottom: .75rem; }
+
+.planName { font-size: 1.15rem; font-weight: 700; margin-bottom: .25rem; }
+
+.price { display: flex; justify-content: center; align-items: baseline; gap: .25rem; }
+.amount { font-size: 2rem; font-weight: 800; }
+.period { opacity: .8; }
+
+.features {
+  margin: .75rem 0 1rem; text-align: left; display: grid; gap: .5rem;
+}
+.featureItem { display: flex; gap: .5rem; align-items: center; }
+
+.actions { margin-top: auto; display: flex; justify-content: center; }


### PR DESCRIPTION
##  PR Amacı
Tek sayfalık landing’de Fiyat Kartları bölümü tamamlandı. Mobil-öncelikli, 3 breakpoint uyumlu ve erişilebilir yapı.

##  Yapılan Değişiklikler
- [x] `src/sections/Pricing` altına Pricing.jsx + Pricing.module.scss
- [x] 3 planlı grid (Starter, Pro, Team) ve “Popüler” rozeti
- [x] CSS vars ile tema uyumlu kart stilleri
- [x] Klavye ile erişim (tabIndex, :focus-visible), aria-etiketleri
- [x] CHANGELOG güncellendi
- [x] Lint başarılı (`npm run lint`)
![Ekran Resmi 2025-11-06 23 29 45](https://github.com/user-attachments/assets/4a8ab8d1-582c-4a7f-ad16-2a996f3b057a)

##  Teknik Detaylar
- Breakpoint’ler: ≤640 (1 kolon), 641–1024 (2), ≥1025 (3)
- Popular plan için border + badge
- Button component varyantları kullanıldı

##  Ekran Görüntüsü
![Ekran Resmi 2025-11-06 23 29 26](https://github.com/user-attachments/assets/6c63956f-49d5-4d93-94e5-acd0a54dded7)


