### PR TITLE
feat: Dark/Light tema switcher eklendi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # 📘 CHANGELOG
 
-## [0.1.0] - 2025-11-07  
+## [0.5.0] - 2025-11-07
+### Added
+- Dark/Light tema geçişi için `ThemeSwitcher` bileşeni eklendi.
+- Tema değişkenleri (`_variables.scss`) güncellendi.
+- Responsive ve erişilebilir tema değiştirici tamamlandı.
+
+## [0.4.0] - 2025-11-07  
 ### Added  
 - Form doğrulama sistemi geliştirildi.  
   - Ad Soyad, E-posta ve Mesaj alanlarında boş alan kontrolü eklendi.  

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,3 +1,4 @@
+import ThemeSwitcher from "./components/ThemeSwitcher/ThemeSwitcher";
 import Contact from "./sections/Contact/Contact";
 import FAQ from "./sections/FAQ/FAQ";
 import Features from "./sections/Features/Features";
@@ -8,6 +9,7 @@ import Pricing from "./sections/Pricing/Pricing";
 function App() {
   return (
     <>
+    <ThemeSwitcher/>
     <Hero/>
     <Features/>
     <Pricing/>

--- a/src/components/ThemeSwitcher/ThemeSwitcher.jsx
+++ b/src/components/ThemeSwitcher/ThemeSwitcher.jsx
@@ -1,0 +1,29 @@
+import { useEffect, useState } from 'react';
+import styles from './ThemeSwitcher.module.scss';
+
+export default function ThemeSwitcher() {
+  const [theme, setTheme] = useState(localStorage.getItem('theme') || 'light');
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(theme === 'light' ? 'dark' : 'light');
+  };
+
+  return (
+    <div className={styles.wrapper}>
+      <label className={styles.switch}>
+        <input
+          type="checkbox"
+          checked={theme === 'dark'}
+          onChange={toggleTheme}
+          aria-label="Tema değiştir (Light/Dark)"
+        />
+        <span className={styles.slider}></span>
+      </label>
+    </div>
+  );
+}

--- a/src/components/ThemeSwitcher/ThemeSwitcher.module.scss
+++ b/src/components/ThemeSwitcher/ThemeSwitcher.module.scss
@@ -1,0 +1,58 @@
+@import '../../styles/variables';
+
+.wrapper {
+  position: fixed;
+  top: 1.5rem;     /* Üstten boşluk */
+  right: 1.5rem;   /* Sağdan sabitleme */
+  z-index: 999;
+}
+
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 50px;
+  height: 26px;
+
+  input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    inset: 0;
+    background-color: var(--border-color);
+    border-radius: 34px;
+    transition: background-color var(--transition);
+
+    &::before {
+      content: "";
+      position: absolute;
+      height: 20px;
+      width: 20px;
+      left: 3px;
+      bottom: 3px;
+      background-color: var(--bg-color);
+      border-radius: 50%;
+      transition: transform var(--transition), background-color var(--transition);
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+    }
+  }
+
+  input:checked + .slider {
+    background-color: var(--primary-color);
+  }
+
+  input:checked + .slider::before {
+    transform: translateX(24px);
+  }
+}
+@media (max-width: 640px) {
+  .wrapper {
+    top: 1rem;
+    right: 1rem;
+    transform: scale(0.9);
+  }
+}

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,21 +1,26 @@
 :root {
-  /* Light tema */
+  /*  Light tema */
   --bg-color: #ffffff;
   --text-color: #111111;
   --primary-color: #0077ff;
   --secondary-color: #f5f5f5;
   --card-bg: #e1e1e6;
   --border-radius: 8px;
+  --border-color: #e0e0e0;
   --transition: 0.3s ease;
 }
 
 [data-theme='dark'] {
+  /*  Dark tema */
   --bg-color: #111111;
   --text-color: #ffffff;
   --primary-color: #3399ff;
   --secondary-color: #1f1f1f;
+  --card-bg: #1a1a1a;
+  --border-color: #333333;
 }
 
+/*  Global değişkenler */
 $font-primary: 'Inter', sans-serif;
 $container-width: 1200px;
 $spacing-unit: 1rem;


### PR DESCRIPTION
## PR AMACI
Bu PR ile sayfanın sağ üst köşesinde **Dark/Light tema geçişi** yapabilen bir `ThemeSwitcher` bileşeni eklendi.  
Kullanıcılar, tema tercihini değiştirebilir ve seçimleri `localStorage` aracılığıyla kalıcı hale getirilir.

---

## Yapılan Değişiklikler
- `ThemeSwitcher.jsx` bileşeni oluşturuldu.
- `ThemeSwitcher.module.scss` dosyası eklendi.
- `variables.scss` içinde tema renkleri (`--bg-color`, `--text-color`, `--primary-color` vs.) tanımlandı.
- Light ve Dark tema CSS değişkenleri ayrıştırıldı.
- Tema geçişi `data-theme` attribute üzerinden çalışacak şekilde uygulandı.
- Responsive konumlandırma (sağ üst köşe, mobilde küçülme) eklendi.

---

## Teknik Detaylar
- Tema durumu `useState` ve `useEffect` ile yönetiliyor.
- Tercih `localStorage`’da saklanıyor.
- CSS geçişi için `transition` değişkeni kullanıldı.
- `position: fixed` ve `z-index: 999` ile her boyutta görünürlük sağlandı.

---

## Erişilebilirlik
- `aria-label="Tema değiştir (Light/Dark)"` eklendi.
- Toggle bileşeni klavye ile aktif edilebilir.

---
###  Görsel / Ekran Görüntüsü
![Ekran Resmi 2025-11-07 03 56 43](https://github.com/user-attachments/assets/ed5d007e-fd1e-4540-b21d-a31f1011ac78)
![Ekran Resmi 2025-11-07 03 56 54](https://github.com/user-attachments/assets/98d10a67-d193-4bee-aa49-809ce77f3793)

![Ekran Resmi 2025-11-07 03 57 25](https://github.com/user-attachments/assets/5d5c33b5-bbb4-444f-b1ed-c837c2feea1c)

### ✅ Kontrol Listesi
- [x] Tema geçişi çalışıyor (light ↔ dark)
- [x] Renk geçişleri yumuşak (CSS vars)
- [x] Responsive görünüm test edildi (320px, 1024px, 1440px)
- [x] Erişilebilirlik (a11y) kuralları kontrol edildi
- [x] Lint hatası yok (`npm run lint`)
